### PR TITLE
fix: 初始化项目时git用户名为汉语的情形

### DIFF
--- a/mcpywrap/utils/project_setup.py
+++ b/mcpywrap/utils/project_setup.py
@@ -21,7 +21,8 @@ def get_git_config_value(key):
             ["git", "config", "--get", key],
             capture_output=True,
             text=True,
-            check=False
+            check=False,
+            encoding="utf-8"
         )
         value = result.stdout.strip()
         return value if value else None


### PR DESCRIPTION
Python默认系统编码在中文Windows下通常是gbk，导致出错。
```shell
Exception in thread Thread-2 (_readerthread):
Traceback (most recent call last):
  File "D:\Program Files\Python312\Lib\threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "D:\Program Files\Python312\Lib\threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "D:\Program Files\Python312\Lib\subprocess.py", line 1599, in _readerthread
    buffer.append(fh.read())
                  ^^^^^^^^^
UnicodeDecodeError: 'gbk' codec can't decode byte 0x87 in position 14: illegal multibyte sequence
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "E:\***\venv\Scripts\mcpy.exe\__main__.py", line 7, in <module>
  File "E:\***\venv\Lib\site-packages\mcpywrap\__main__.py", line 10, in main
    cli()
  File "E:\***\venv\Lib\site-packages\click\core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\***\venv\Lib\site-packages\click\core.py", line 1363, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "E:\***\venv\Lib\site-packages\click\core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\***\venv\Lib\site-packages\click\core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\***\venv\Lib\site-packages\click\core.py", line 794, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\***\venv\Lib\site-packages\mcpywrap\commands\init_cmd.py", line 39, in init_cmd
    init()
  File "E:\***\venv\Lib\site-packages\mcpywrap\commands\init_cmd.py", line 113, in init
    default_author = get_default_author()
                     ^^^^^^^^^^^^^^^^^^^^
  File "E:\***\venv\Lib\site-packages\mcpywrap\utils\project_setup.py", line 34, in get_default_author
    git_author = get_git_config_value("user.name")
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\***\venv\Lib\site-packages\mcpywrap\utils\project_setup.py", line 26, in get_git_config_value
    value = result.stdout.strip()
            ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'strip'
```